### PR TITLE
added linting config files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+pretty:
+	black --config black.toml .
+
+lint:
+	black --config black.toml --check .
+	flake8 --config setup.cfg .

--- a/black.toml
+++ b/black.toml
@@ -1,0 +1,4 @@
+[tool.black]
+skip-string-normalization = true
+target-version = ['py38']
+exclude = 'config.py'

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,31 @@
+
+[tool:pytest]
+testpaths = tests
+
+[coverage:run]
+branch = True
+source =
+    src
+
+[flake8]
+ignore =
+    # E203 - Whitespace before ':'
+    E203,
+    # E266 - Too many leading '#' for block comment
+    E266,
+    # E501 - Line too long
+    E501,
+    # W503 - Line break before binary operator
+    W503
+    # E731 - Do not assign a lambda expression
+    E731
+statistics = True
+exclude =
+    # Not mine
+    diffvg,
+    # draft files are quick things I try out
+    draft_*
+    # temporary
+    loss.py
+    # Ignore old files
+    olds


### PR DESCRIPTION
This is what I use to lint the python code, so it's easy to read, has no unnecessary imports. I think this is particularly useful in that it guarantees that if the names of the objects are the same, then our codes will match exaclty. To use it, I just run

`make pretty`

to **automatically modify/align the code**, and

`make lint`

to check if there are unused imports and such. You can modify the linters' configurations on black.toml and setup.cfg, which are pretty much self explanatory.

I am not trying to say you **have to use this**, it's only a suggestion to make your life easier.